### PR TITLE
修复了JWT 拦截器配置错误地排除了整个/api/tutor/*路径

### DIFF
--- a/campus-backend/src/main/java/com/campus/config/WebMvcConfig.java
+++ b/campus-backend/src/main/java/com/campus/config/WebMvcConfig.java
@@ -32,7 +32,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
                         "/api/match/tutors",
                         "/api/demand/list",
                         "/api/demand/nearby",
-                        "/api/tutor/*"
+                        "/api/tutor/public/**"
                 );
     }
 

--- a/campus-backend/src/main/java/com/campus/module/tutor/controller/TutorController.java
+++ b/campus-backend/src/main/java/com/campus/module/tutor/controller/TutorController.java
@@ -68,7 +68,7 @@ public class TutorController {
     }
 
     @Operation(summary = "根据ID获取教员档案(公开)")
-    @GetMapping("/{id}")
+    @GetMapping("/public/{id}")
     public Result<TutorProfile> getById(@PathVariable Long id) {
         TutorProfile profile = tutorProfileService.getById(id);
         return Result.success(profile);


### PR DESCRIPTION
修复了issue中提到的

查询时 user_id = null：==> Parameters: null
插入时 SQL 语句中缺少 user_id 字段
这说明 UserContext.getCurrentUserId() 返回了 null，导致在创建 TutorProfile 时没有设置 user_id。
规则把 /api/tutor/certification 排除在 JWT 拦截器之外

